### PR TITLE
fix(get-script-map): use specific sdk patch version

### DIFF
--- a/src/utils/get-script-map.ts
+++ b/src/utils/get-script-map.ts
@@ -7,7 +7,7 @@ export interface ScriptMap {
 export function getScriptMap(secure?: boolean): ScriptMap {
   // store the versions of the HERE API
   const apiVersion = "v3";
-  const codeVersion = "3.1";
+  const codeVersion = "3.1.61.1";
 
   // get the relevant protocol for the HERE Maps API
   let protocol = "";


### PR DESCRIPTION
## What the PR Includes
- [x] use specific sdk patch version (3.1.61.1) to fix a regression introduced in 3.1.61.2 related to map zoom.

## Checklist
- [ ] Tests are added.
- [ ] Manual testing instructions are added.
- [ ] Configs are added/adapted if applicable.
- [ ] Issue is properly linked if applicable.

## Manual Testing Instructions
1. 