### PR TITLE
fix(heremap): preserve integer zoom when focusing on markers

### DIFF
--- a/src/HEREMap.tsx
+++ b/src/HEREMap.tsx
@@ -59,8 +59,8 @@ export interface HEREMapRef {
   setCenter: (point: H.geo.IPoint) => void,
   setZoom: (zoom: number) => void,
   screenToGeo: (x: number, y: number) => H.geo.Point,
-  zoomOnMarkers: (animate?: boolean, group?: string) => void,
-  zoomOnMarkersSet: (markersSet: H.map.DomMarker[], animate?: boolean) => void,
+  zoomOnMarkers: (animate?: number | boolean, group?: string) => void,
+  zoomOnMarkersSet: (markersSet: H.map.DomMarker[], animate?: number | boolean) => void,
   addToMarkerGroup: (marker: H.map.Marker, group: string) => void,
   removeFromMarkerGroup: (marker: H.map.Marker, group: string) => void,
 }
@@ -123,7 +123,7 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
     return map.screenToGeo(x, y)
   }
 
-  const zoomOnMarkersGroup = (markersGroup: H.map.Group, animate: boolean = true) => {
+  const zoomOnMarkersGroup = (markersGroup: H.map.Group, animate: number | boolean = true) => {
     const DISTANCE_FACTOR = 0.1
     const BEARING_TOP_LEFT = 315
     const BEARING_BOTTOM_RIGHT = 135
@@ -138,14 +138,14 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
     if (viewBounds) { map.getViewModel().setLookAtData({ bounds: viewBounds }, animate, true) }
   }
 
-  const zoomOnMarkers = (animate: boolean = true, group: string = 'default') => {
+  const zoomOnMarkers = (animate: number | boolean = true, group: string = 'default') => {
     if (map) {
       if (!markersGroupsRef.current[group]) { return }
       zoomOnMarkersGroup(markersGroupsRef.current[group], animate)
     }
   }
 
-  const zoomOnMarkersSet = (markersSet: H.map.DomMarker[], animate: boolean = true) => {
+  const zoomOnMarkersSet = (markersSet: H.map.DomMarker[], animate: number | boolean = true) => {
     const markersGroupSet = new H.map.Group()
     markersSet.map((m) => markersGroupSet.addObject(m))
     zoomOnMarkersGroup(markersGroupSet, animate)

--- a/src/HEREMap.tsx
+++ b/src/HEREMap.tsx
@@ -135,7 +135,7 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
       topLeft.walk(BEARING_TOP_LEFT, distance),
       bottomRight.walk(BEARING_BOTTOM_RIGHT, distance),
     )
-    if (viewBounds) { map.getViewModel().setLookAtData({ bounds: viewBounds }, animate) }
+    if (viewBounds) { map.getViewModel().setLookAtData({ bounds: viewBounds }, animate, true) }
   }
 
   const zoomOnMarkers = (animate: boolean = true, group: string = 'default') => {


### PR DESCRIPTION
## What the PR Includes
- [x] preserve integer zoom when focusing on markers.

Because of how raster tiles work, the tiles are different based on the zoom level. For example: When zoom level is 12, a tile image covers a certain area, when zooming in to level 13 (meaning, the same land area occupies bigger screen space), a new image needs to be fetched to cover the smaller area.

If fractional zooming is allowed, then a level 12.4 or 12.5 zoom is possible. In this case, the level 12 tiles are still used, but they are stretched over bigger screen space, leading to blurriness. 

This change ensures that zoom levels are always integers by passing `opt_integerZoom=true` to `setLookAtData` when zooming on a marker or a group of markers.
