### PR TITLE
feat: improve tiles on high pixel ratio screens

### DIFF
--- a/src/HEREMap.tsx
+++ b/src/HEREMap.tsx
@@ -230,9 +230,14 @@ export const HEREMap = forwardRef<HEREMapRef, HEREMapProps>(({
       apikey: apiKey,
     })
 
+    const ppi = engineType === H.Map.EngineType.P2D
+      ? hidpi ? 320 : 72
+      : undefined
+
     defaultLayersRef.current = platform.createDefaultLayers({
       lg: getTileLanguage(language),
       engineType,
+      ppi,
     }) as DefaultLayers
 
     const hereMapEl = document.querySelector(`#map-container-${uniqueIdRef.current}`) as HTMLElement

--- a/src/useLegacyRasterLayers.ts
+++ b/src/useLegacyRasterLayers.ts
@@ -23,7 +23,7 @@ export const getLayers = (
   hidpi?: boolean,
 ) => {
   const lang = getTileLanguage(language)
-  const ppi = hidpi ? 400 : 100
+  const ppi = hidpi ? 200 : 100
   const format = 'png8'
 
   const getTrafficOverlayProvider = (): H.map.provider.ImageTileProvider.Options => {

--- a/src/useRasterLayers.ts
+++ b/src/useRasterLayers.ts
@@ -34,7 +34,7 @@ const getBaseLayer = ({
   const service = platform.getRasterTileService({
     queryParams: {
       lang,
-      ppi: hidpi ? 200 : 100,
+      scale: hidpi ? 2 : 1,
       style: trafficLayer ? 'lite.day' : 'logistics.day',
       ...(congestion
         ? {
@@ -45,7 +45,7 @@ const getBaseLayer = ({
   })
 
   const provider =
-    new H.service.rasterTile.Provider(service, { engineType: H.Map.EngineType.HARP, tileSize: 256 })
+    new H.service.rasterTile.Provider(service, { engineType: H.Map.EngineType.HARP, tileSize: hidpi ? 512 : 256 })
 
   return new H.map.layer.TileLayer(provider)
 }
@@ -68,12 +68,12 @@ const getTruckOverlayLayer = ({
       features: `vehicle_restrictions:${showActiveAndInactiveTruckRestrictions ? 'active_and_inactive' : 'permanent_only'}`,
       style: 'logistics.day',
       lang,
-      ppi: hidpi ? 200 : 100,
+      scale: hidpi ? 2 : 1,
     },
   })
 
   const truckOverlayProvider =
-    new H.service.rasterTile.Provider(truckOnlyTileService, { engineType: H.Map.EngineType.HARP, tileSize: 256 })
+    new H.service.rasterTile.Provider(truckOnlyTileService, { engineType: H.Map.EngineType.HARP, tileSize: hidpi ? 512 : 256 })
 
   return new H.map.layer.TileLayer(truckOverlayProvider)
 }

--- a/testbench/index.html
+++ b/testbench/index.html
@@ -1,4 +1,7 @@
 <html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0,user-scalable=0">
+</head>
 <body>
   <div id="root" height="100%" width="100%"></div>
   <script src="./index.tsx" type="module"></script>


### PR DESCRIPTION
## What the PR Includes
- [x] improve tiles (specially text labels) on high pixel ratio screens. This affects both P2D and HARP layers.

Closes POS-2153

## Checklist
- [ ] Tests are added.
- [ ] Manual testing instructions are added.
- [ ] Configs are added/adapted if applicable.
- [ ] Issue is properly linked if applicable.

## Manual Testing Instructions
1. Using the testbench and the devtools, try out different DPR (1, 2, ...) and different zoom levels
2. See that the map labels stay readable 
3. See that the map quality is not severely degraded